### PR TITLE
feat/optional example mails

### DIFF
--- a/src/main/java/com/github/ksokol/mailsink/bootstrap/ExampleMailApplicationRunner.java
+++ b/src/main/java/com/github/ksokol/mailsink/bootstrap/ExampleMailApplicationRunner.java
@@ -2,6 +2,7 @@ package com.github.ksokol.mailsink.bootstrap;
 
 import com.github.ksokol.mailsink.repository.MailRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -17,12 +18,17 @@ class ExampleMailApplicationRunner implements ApplicationRunner {
     @Autowired
     private ExampleMails exampleMails;
 
+    @Value("${mailsink.create-examples}")
+    private Boolean createExamples;
+
     public ExampleMailApplicationRunner(MailRepository mailRepository) {
         this.mailRepository = mailRepository;
     }
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
-        exampleMails.listExampleMails().forEach(mailRepository::save);
+        if (createExamples) {
+            exampleMails.listExampleMails().forEach(mailRepository::save);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ server.port=2525
 
 spring.mail.port=2500
 spring.mail.host=localhost
+
+mailsink.create-examples=true


### PR DESCRIPTION
Add configuration option to disable example emails.
They are still being created by default (unchanged).